### PR TITLE
fix: docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,5 @@ __pycache__/
 *.pyc
 .git/
 .gitignore
-README.md
-*.md
 .pytest_cache/
 tasks.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY pyproject.toml ./
 RUN uv sync --no-install-project --no-editable
 
 # Copy the project into the intermediate image
-COPY . /cc_simple_server ./
+COPY . ./
 
 # Sync the project
 RUN uv sync --no-editable


### PR DESCRIPTION
remove readme ignore in the .dockerignore because python dependencies require the existance of a readme smh. `uv sync` is requiring the presence of a README